### PR TITLE
add log flags to help with debugging

### DIFF
--- a/wtf.go
+++ b/wtf.go
@@ -207,6 +207,7 @@ func loadConfig(configFlag string) {
 }
 
 func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	cmdFlags := wtf.NewCommandFlags()
 	cmdFlags.Parse(version)


### PR DESCRIPTION
Hi, After cloning, I tried to start wtf with the `complex_config.yml` file, but I kept getting this error:

```
2018/06/02 23:01:13 invalid api key
```

After some digging, it turned out the error was from [here](https://github.com/briandowns/openweathermap/blob/722564b6cf670ef4a8fce54d8913ac9a13e88ec1/openweathermap.go#L149) . 

With this change I'm proposing, the error output is a bit more helpful:

```
2018/06/02 23:03:45 openweathermap.go:149: invalid api key
```

